### PR TITLE
EBILL-175: Made ticket type required

### DIFF
--- a/ding_pretix.module
+++ b/ding_pretix.module
@@ -397,6 +397,7 @@ function ding_pretix_form_ding_event_node_form_alter(&$form, &$form_state, $form
       'pdf_ticket' => t('PDF Tickets'),
       'email_ticket' => t('Email Tickets'),
     ],
+    '#required' => TRUE,
     '#default_value' => $ticket_form,
     '#description' => t('Use PDF or Email tickets for the event?'),
   ];

--- a/includes/ding_pretix.admin.inc
+++ b/includes/ding_pretix.admin.inc
@@ -223,6 +223,7 @@ function ding_pretix_admin_settings_form($form, &$form_state) {
       'pdf_ticket' => t('PDF Tickets'),
       'email_ticket' => t('Email Tickets'),
     ],
+    '#required' => TRUE,
     '#default_value' => array_key_exists('default_ticket_form', $defaults) ? $defaults['default_ticket_form'] : [],
     '#description' => t('Should new events use PDF or Email tickets by default?'),
   ];


### PR DESCRIPTION
Not selecting a ticket type will result in 

```
PDOException: SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ')' at line 1: INSERT INTO {ding_pretix} (nid, pretix_organizer, pretix_slug, capacity, maintain_copy, psp_element, ticket_form) VALUES (:db_insert_placeholder_0, :db_insert_placeholder_1, :db_insert_placeholder_2, :db_insert_placeholder_3, :db_insert_placeholder_4, :db_insert_placeholder_5, ); Array ( [:db_insert_placeholder_0] => 51 [:db_insert_placeholder_1] => aakb [:db_insert_placeholder_2] => 51 [:db_insert_placeholder_3] => 0 [:db_insert_placeholder_4] => 1 [:db_insert_placeholder_5] => ) i _ding_pretix_insert_pretix_node_info() (linje 719 af /vagrant/htdocs/sites/all/modules/ding_pretix/includes/ding_pretix.api_module.inc).
```
I don't understand why `db_merge` doesn't prevent this SQL syntax error.

This fix makes the ticket type required in both default settings and when editing an event.