### PR TITLE
EBILL-175: Added load of node pretix data

### DIFF
--- a/ding_pretix.module
+++ b/ding_pretix.module
@@ -485,3 +485,24 @@ function ding_pretix_clone_node_alter(&$node, $context) {
     }
   }
 }
+
+/**
+ * Implements hook_node_load().
+ */
+function ding_pretix_node_load($nodes, $types) {
+  if (in_array('ding_event', $types)) {
+    $result = db_query('SELECT * FROM {ding_pretix} WHERE nid IN (:nids)', [
+      ':nids' => array_keys($nodes),
+    ]);
+
+    foreach ($result as $record) {
+      $nodes[$record->nid]->pretix = [
+        'nid' => (int) $record->nid,
+        'capacity' => (int) $record->capacity,
+        'maintain_copy' => (int) $record->maintain_copy,
+        'psp_element' => $record->psp_element,
+        'ticket_form' => $record->ticket_form,
+      ];
+    }
+  }
+}


### PR DESCRIPTION
https://jira.itkdev.dk/browse/AAKBET-626

When disabling a user and anonymizing his `ding_event` nodes, `$node->pretix` is not set when [`ding_pretix_node_update`](https://github.com/aakbcms/ding_pretix/blob/develop/ding_pretix.module#L124) is run. Therefore the event is taken offline in pretix (cf. https://github.com/aakbcms/ding_pretix/blob/develop/ding_pretix.module#L173).

This fix adds a `node_load` hook that populates `$node->pretix` whenever a node is loaded. 

Currently, `$node->pretix` is apparently only defined right after the node has been manipulated manually via the node edit form. 